### PR TITLE
Current user object id fix

### DIFF
--- a/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
@@ -89,6 +89,7 @@ if ($azContext.Account.Type -eq "User") {
         # Selecting the same subscription with the same tenant (twice), brings us back to the UPN
         Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
         Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        $azContext = Get-AzContext
         Write-Host "Current context is user: $($azContext.Account.Id)"
         $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id    
     }

--- a/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
@@ -84,6 +84,15 @@ if ($azContext.Account.Type -eq "User") {
 
     $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id
 
+    if (!$currentUser) {
+        # For some reason $azContext.Account.Id will sometimes be the email of the user instead of the UPN, we need the UPN
+        # Selecting the same subscription with the same tenant (twice), brings us back to the UPN
+        Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        Write-Host "Current context is user: $($azContext.Account.Id)"
+        $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id    
+    }
+
     #If this is guest account, we will try a search instead
     if (!$currentUser) {
         # External user accounts have UserPrincipalNames of the form:

--- a/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
@@ -87,9 +87,18 @@ catch {
 }
 
 if ($azContext.Account.Type -eq "User") {
+
     Write-Host "Current context is user: $($azContext.Account.Id)"
-    
     $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id
+
+    if (!$currentUser) {
+        # For some reason $azContext.Account.Id will sometimes be the email of the user instead of the UPN, we need the UPN
+        # Selecting the same subscription with the same tenant (twice), brings us back to the UPN
+        Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        Write-Host "Current context is user: $($azContext.Account.Id)"
+        $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id    
+    }
 
     #If this is guest account, we will try a search instead
     if (!$currentUser) {

--- a/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
@@ -87,7 +87,6 @@ catch {
 }
 
 if ($azContext.Account.Type -eq "User") {
-
     Write-Host "Current context is user: $($azContext.Account.Id)"
     $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id
 
@@ -96,6 +95,7 @@ if ($azContext.Account.Type -eq "User") {
         # Selecting the same subscription with the same tenant (twice), brings us back to the UPN
         Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
         Select-AzSubscription -SubscriptionId $azContext.Subscription.Id -TenantId $azContext.Tenant.Id | Out-Null
+        $azContext = Get-AzContext
         Write-Host "Current context is user: $($azContext.Account.Id)"
         $currentUser = Get-AzADUser -UserPrincipalName $azContext.Account.Id    
     }


### PR DESCRIPTION
Small workaround to attempt to find user object id when $(Get-AzContext).Account.Id returns the user email instead of the UPN.