### PR TITLE
Remove dependency on git of environment scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
-fhir-server/
+fhir-server*/
 
 #VSCode
 .vscode/

--- a/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
@@ -61,11 +61,14 @@ catch {
 if (Get-Module -Name FhirServer) {
     Write-Host "FhirServer PS module is loaded"
 } else {
-    Write-Host "Cloning FHIR Server repo to get access to FhirServer PS module."
-    if (!(Test-Path -Path ".\fhir-server")) {
-        git clone --quiet https://github.com/Microsoft/fhir-server | Out-Null
+    Write-Host "Fetching FHIR Server repo to get access to FhirServer PS module."
+    $fhirServerVersion = 'master'
+    if (!(Test-Path -Path ".\fhir-server-$fhirServerVersion")) {
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD\fhir-server-$fhirServerVersion.zip")
+        Expand-Archive -Path ".\fhir-server-$fhirServerVersion.zip" -DestinationPath "$PWD"
+        Remove-Item ".\fhir-server-$fhirServerVersion.zip"
     }
-    Import-Module .\fhir-server\samples\scripts\PowerShell\FhirServer\FhirServer.psd1
+    Import-Module ".\fhir-server-$fhirServerVersion\samples\scripts\PowerShell\FhirServer\FhirServer.psd1"
 }
 
 $keyVault = Get-AzKeyVault -VaultName $KeyVaultName

--- a/deploy/scripts/Delete-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Delete-FhirServerSamplesAuthConfig.ps1
@@ -36,11 +36,14 @@ catch {
 if (Get-Module -Name FhirServer) {
     Write-Host "FhirServer PS module is loaded"
 } else {
-    Write-Host "Cloning FHIR Server repo to get access to FhirServer PS module."
-    if (!(Test-Path -Path ".\fhir-server")) {
-        git clone --quiet https://github.com/Microsoft/fhir-server | Out-Null
+    Write-Host "Fetching FHIR Server repo to get access to FhirServer PS module."
+    $fhirServerVersion = 'master'
+    if (!(Test-Path -Path ".\fhir-server-$fhirServerVersion")) {
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD\fhir-server-$fhirServerVersion.zip")
+        Expand-Archive -Path ".\fhir-server-$fhirServerVersion.zip" -DestinationPath "$PWD"
+        Remove-Item ".\fhir-server-$fhirServerVersion.zip"
     }
-    Import-Module .\fhir-server\samples\scripts\PowerShell\FhirServer\FhirServer.psd1
+    Import-Module ".\fhir-server-$fhirServerVersion\samples\scripts\PowerShell\FhirServer\FhirServer.psd1"
 }
 
 $fhirServiceName = "${EnvironmentName}srvr"


### PR DESCRIPTION
Currently the `Create-FhirServerSamplesAuthConfig.ps1` and `Delete-FhirServerSamplesAuthConfig.ps1` deployment scripts assume that the user has git installed on their system. However, there are situations in which git will not be available, e.g. if the user is using git from WSL but runs the deployment scripts from Windows (I personally just ran into this scenario), or if the user downloaded the fhir-server-samples repository from Github manually as opposed to cloning it.

This pull request removes the dependency on git by fetching the fhir-server code as a zip file via a HTTP request to Github's code download endpoint (see [StackOverflow](https://stackoverflow.com/q/2751227) and [Github docs](https://developer.github.com/v3/repos/contents/#download-a-repository-archive)). Besides removing an external dependency, this approach also has the advantage that the scripts now no longer have to fetch the entire git history and instead only fetch the code at a particular commit which in my tests reduced the download size considerably (17 MB for git clone versus 2 MB for the zip file).