### PR TITLE
Add PowerShell version of FhirImporter

### DIFF
--- a/src/FhirImporter/FhirImporter.ps1
+++ b/src/FhirImporter/FhirImporter.ps1
@@ -1,0 +1,89 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Imports data into an Azure FHIR server.
+.DESCRIPTION
+#>
+param (
+  [Parameter(Mandatory=$true)]
+  [string]
+  [ValidatePattern('^https://[^.]+\.azurehealthcareapis\.com$')]
+  $FhirServerUrl,
+
+  [Parameter(Mandatory=$true)]
+  [string]
+  [ValidateScript({ if (!(Test-Path $_ -PathType Container)) { throw 'Must be a directory' } else { return $true } })]
+  $BundlesDirectory
+)
+
+if (!(Get-Command az -ErrorAction SilentlyContinue))
+{
+  throw 'Please install Azure CLI: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli'
+}
+
+try
+{
+  $user = az account show --query 'user.name' --output tsv
+}
+catch
+{
+  throw 'Please log in to Azure CLI with the az login command before proceeding'
+}
+
+Write-Output "Getting access token for $FhirServerUrl"
+
+$fhirResourceName = ($FhirServerUrl | Select-String -Pattern '^https://([^.]+)\.azurehealthcareapis\.com$').Matches.Groups[1].Value
+
+$fhirResourceId = az resource list `
+  --namespace Microsoft.HealthcareApis `
+  --resource-type services `
+  --name $fhirResourceName `
+  --query '[0].id' `
+  --output tsv
+
+$roleAssignmentResourceId = az role assignment create `
+  --assignee $user `
+  --scope $fhirResourceId `
+  --role 'FHIR Data Contributor' `
+  --query 'id' `
+  --output tsv
+
+try
+{
+  $accessToken = az account get-access-token `
+    --resource $FhirServerUrl `
+    --query 'accessToken' `
+    --output tsv
+
+  $jsonFiles = Get-ChildItem -Path $BundlesDirectory -Filter '*.json'
+
+  foreach ($jsonFile in $jsonFiles)
+  {
+    Write-Output "Processing file $jsonFile"
+    $bundle = Get-Content $jsonFile.FullName | ConvertFrom-Json
+
+    foreach ($entry in $bundle.entry)
+    {
+      $headers = @{}
+      $headers.Add('Authorization', "Bearer $accessToken")
+      $headers.Add('Content-Type', 'application/fhir+json')
+
+      $response = Invoke-WebRequest `
+        -Uri $($FhirServerUrl + '/' + $entry.request.url) `
+        -Method $entry.request.method `
+        -Body $(ConvertTo-Json $entry.resource -Depth 10) `
+        -Headers $headers `
+        -UseBasicParsing
+
+      $resourceUri = $response.Headers['Location']
+      Write-Output "Imported resource $resourceUri"
+    }
+  }
+}
+finally
+{
+  Write-Output 'Cleaning up'
+  az role assignment delete `
+    --id $roleAssignmentResourceId `
+    --yes
+}

--- a/src/FhirImporter/README.md
+++ b/src/FhirImporter/README.md
@@ -1,4 +1,6 @@
-# Azure FHIR Importer Function
+# Importing data into Azure FHIR
+
+## FHIR Importer Function
 
 The Azure function app will monitor a `fhirimport` container in the attached storage account and ingest patient bundles into the FHIR service.
 
@@ -66,3 +68,10 @@ where `aci-template.parameters.json` is a parameter file with the following cont
 }
 ```
 
+## FHIR Importer Script
+
+For ad-hoc data imports from the local file system to a [Azure API for FHIR](https://docs.microsoft.com/azure/healthcare-apis), the `FhirImporter.ps1` script can be used:
+
+```
+.\FhirImporter.ps1 -FhirServerUrl https://<myaccountname>.azurehealthcareapis.com -BundlesDirectory <path to data files>
+```


### PR DESCRIPTION
The FhirImporter Azure Function in this repository is tremendously useful for bootstrapping environments for Azure API for FHIR. However, in some situations the overhead of setting up the function app, the RBAC rules, the storage account, etc. can be non-desirable, e.g. when setting up personal development environments and wanting to iterate quickly on data imports. As such, this pull request adds a PowerShell script that emulates the functionality of the FhirImporter Azure Function and pushes data files from the local drive into an Azure API for FHIR.

The script works nicely for data files generated by [synthea](https://github.com/synthetichealth/synthea), e.g. using this approach:

```pwsh
# generate synthetic data
git clone "https://github.com/synthetichealth/synthea"
Push-Location .\synthea
& .\run_synthea -s 1234 -p 25
Get-ChildItem .\output\bundle\fhir
Pop-Location

# import data into fhir server
git clone "https://github.com/microsoft/fhir-server-samples.git"
Push-Location .\fhir-server-samples
.\src\FhirImporter\FhirImporter.ps1 -FhirServerUrl https://<myaccountname>.azurehealthcareapis.com -BundlesDirectory ..\synthea\output\bundle\fhir
Pop-Location
```