### PR TITLE
Allow East US FHIR API

### DIFF
--- a/deploy/templates/azuredeploy-sandbox.json
+++ b/deploy/templates/azuredeploy-sandbox.json
@@ -98,7 +98,7 @@
         },
         "fhirApiLocation": {
             "type": "string",
-            "allowedValues": [ "westus2", "northcentralus", "ukwest", "uksouth", "southeastasia", "australiaeast", "westeurope" ],
+            "allowedValues": [ "eastus", "westus2", "northcentralus", "ukwest", "uksouth", "southeastasia", "australiaeast", "westeurope" ],
             "defaultValue": "westus2",
             "metadata": {
                 "description": "Location of Azure API for FHIR"


### PR DESCRIPTION
I couldn't deploy the sample environment to eastus, but my Azure API for FHIR was in eastus.  This helped me deploy to eastus.