### PR TITLE
Replace master with main to download fhir-server repo archive correctly. Add missing parenthesis.

### DIFF
--- a/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesAuthConfig.ps1
@@ -62,9 +62,9 @@ if (Get-Module -Name FhirServer) {
     Write-Host "FhirServer PS module is loaded"
 } else {
     Write-Host "Fetching FHIR Server repo to get access to FhirServer PS module."
-    $fhirServerVersion = 'master'
+    $fhirServerVersion = 'main'
     if (!(Test-Path -Path ".\fhir-server-$fhirServerVersion")) {
-        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD\fhir-server-$fhirServerVersion.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD/fhir-server-$fhirServerVersion.zip")
         Expand-Archive -Path ".\fhir-server-$fhirServerVersion.zip" -DestinationPath "$PWD"
         Remove-Item ".\fhir-server-$fhirServerVersion.zip"
     }

--- a/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
+++ b/deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
@@ -54,6 +54,7 @@ param
     [parameter(Mandatory = $false)]
     [SecureString]$AdminPassword
 
+)
 
 function SecretValueText
 {

--- a/deploy/scripts/Delete-FhirServerSamplesAuthConfig.ps1
+++ b/deploy/scripts/Delete-FhirServerSamplesAuthConfig.ps1
@@ -37,9 +37,9 @@ if (Get-Module -Name FhirServer) {
     Write-Host "FhirServer PS module is loaded"
 } else {
     Write-Host "Fetching FHIR Server repo to get access to FhirServer PS module."
-    $fhirServerVersion = 'master'
+    $fhirServerVersion = 'main'
     if (!(Test-Path -Path ".\fhir-server-$fhirServerVersion")) {
-        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD\fhir-server-$fhirServerVersion.zip")
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/Microsoft/fhir-server/archive/$fhirServerVersion.zip", "$PWD/fhir-server-$fhirServerVersion.zip")
         Expand-Archive -Path ".\fhir-server-$fhirServerVersion.zip" -DestinationPath "$PWD"
         Remove-Item ".\fhir-server-$fhirServerVersion.zip"
     }


### PR DESCRIPTION
1. Replaced master with main since https://github.com/microsoft/fhir-server no longer uses _master_ branch. Instead it's called _main_ now.
2. Replaced \ with  / in (New-Object System.Net.WebClient).DownloadFile() call since \ isn't working.
3. Added missing  parenthesis for param block in deploy/scripts/Create-FhirServerSamplesEnvironment.ps1
